### PR TITLE
Support UNIX socket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ ships:
         tls_cert: cert.pem
 ```
 
+When Maestro is launched on the same host as the Docker daemon, it is
+possible to specify a UNIX socket instead of an IP address:
+
+```yaml
+ships:
+  local: {unix: /var/run/docker.sock}
+```
+
 Services are also named. Their name is used for commands that act on
 specific services instead of the whole environment, and is also used in
 dependency declarations. Each service must define the Docker image its

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -60,9 +60,10 @@ class Ship(Entity):
     DEFAULT_DOCKER_VERSION = '1.10'
     DEFAULT_DOCKER_TIMEOUT = 5
 
-    def __init__(self, name, ip, endpoint=None, docker_port=None, timeout=None,
-                 ssh_tunnel=None, tls=None, tls_verify=False, tls_ca_cert=None,
-                 tls_cert=None, tls_key=None, ssl_version=None):
+    def __init__(self, name, ip=None, endpoint=None, docker_port=None, 
+                 timeout=None, ssh_tunnel=None, tls=None, tls_verify=False, 
+                 tls_ca_cert=None, tls_cert=None, tls_key=None, 
+                 ssl_version=None, unix_socket=None):
         """Instantiate a new ship.
 
         Args:
@@ -71,6 +72,8 @@ class Ship(Entity):
             docker_port (int): the port the Docker daemon listens on.
             ssh_tunnel (dict): configuration for SSH tunneling to the remote
                 Docker daemon.
+            unix_socket (string): path to an UNIX socket to use instead of an
+                IP connection
         """
         Entity.__init__(self, name)
         self._ip = ip
@@ -102,6 +105,9 @@ class Ship(Entity):
             # Apparently bgtunnel isn't always ready right away and this
             # drastically cuts down on the timeouts
             time.sleep(1)
+
+        elif unix_socket:
+            self._backend_url = 'unix://%s' % unix_socket
 
         else:
             proto = "https" if (tls or tls_verify) else "http"

--- a/maestro/shipproviders.py
+++ b/maestro/shipproviders.py
@@ -43,7 +43,7 @@ class StaticShipsProvider(ShipsProvider):
         # Create container ships.
         self._ships = dict(
             (k, entities.Ship(
-                k, ip=v['ip'], endpoint=v.get('endpoint'),
+                k, ip=v.get('ip', None), endpoint=v.get('endpoint'),
                 docker_port=self._from_ship_or_defaults(v, 'docker_port'),
                 ssh_tunnel=self._from_ship_or_defaults(v, 'ssh_tunnel'),
                 timeout=self._from_ship_or_defaults(v, 'timeout'),
@@ -52,7 +52,8 @@ class StaticShipsProvider(ShipsProvider):
                 tls_key=v.get('tls_key', None),
                 tls_verify=v.get('tls_verify', False),
                 tls_ca_cert=v.get('tls_ca_cert', None),
-                ssl_version=v.get('ssl_version', None)))
+                ssl_version=v.get('ssl_version', None),
+                unix_socket=v.get('unix', None)))
             for k, v in self._config['ships'].items())
 
     def ships(self):


### PR DESCRIPTION
By default Docker only listens on a UNIX socket, and enabling the TCP server may be a security hole in some environments. Maestro should be able to connect to the UNIX socket when run on the same host.