### PR TITLE
Fix a bug in error handling for Timeouts

### DIFF
--- a/maestro/maestro.py
+++ b/maestro/maestro.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import functools
 import inspect
 import requests.exceptions
+import sys
 
 from . import audit
 from . import entities
@@ -216,14 +217,15 @@ class Conductor:
         try:
             play.run()
             self.auditor.success(things, action)
-        except requests.exceptions.Timeout as e:
+        except requests.exceptions.Timeout:
+            e_type, e, tb = sys.exc_info()
             try:
                 msg = e.args[0][1]
             except:
                 # varies with the timeout exception
                 msg = e.args[0][0]
             self.auditor.error(things, action, message=msg)
-            raise
+            raise e_type, e, tb
         except Exception as e:
             self.auditor.error(things, action, message=e)
             raise


### PR DESCRIPTION
When a Timeout is caught, and `msg = e.args[0][1]` errors and is handled,
the subsequent `raise` does not raise the Timeout as intended, but instead
raises the IndexError that was previously handled, as it was the most recent exception.

This is fixed by saving the exception and traceback info, then raising
it explicitly instead of raising the most recent exception.