### PR TITLE
Let ships connect to a local unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ listen on anything else than `localhost`, and rely on SSH key-based
 authentication instead). Here again, if the `endpoint` parameter is
 specified, it will be used as the target host for the SSH connection.
 
+If the Docker daemon is listening on a unix domain socket in the local
+filesystem, you can specify `socket_path` to connect to it directly.
+This is useful when the Docker daemon is running locally.
+
 ```yaml
 ships:
   vm1.ore1: {ip: c414.ore1.domain.com}

--- a/maestro/shipproviders.py
+++ b/maestro/shipproviders.py
@@ -45,6 +45,7 @@ class StaticShipsProvider(ShipsProvider):
             (k, entities.Ship(
                 k, ip=v['ip'], endpoint=v.get('endpoint'),
                 docker_port=self._from_ship_or_defaults(v, 'docker_port'),
+                socket_path=self._from_ship_or_defaults(v, 'socket_path'),
                 ssh_tunnel=self._from_ship_or_defaults(v, 'ssh_tunnel'),
                 timeout=self._from_ship_or_defaults(v, 'timeout'),
                 tls=v.get('tls', False),


### PR DESCRIPTION
Add a ship config option to allow ships to connect to docker via a unix socket
This is useful for local testing, since this is the default setting for docker and
more secure than a local tcp socket.

I investigated trying to make unix socket forwarding over ssh work, but the bgtunnel library does not support it (though it would be trivial to do so - it just needs to pass a path instead of "localhost:PORT" to the ssh -L option).