### PR TITLE
Add support for volume with no host bindind using schema version 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /maestro.egg-info/
 *.pyc
 /.tox
+*.swp

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -577,8 +577,11 @@ class Container(Entity):
             if isinstance(spec, six.string_types):
                 result[src] = {'bind': spec, 'ro': False}
             elif type(spec) == dict and 'target' in spec:
-                result[src] = {'bind': spec['target'],
-                               'ro': spec.get('mode', 'rw') == 'ro'}
+                result[src] = {'bind': spec['target'], 'ro': spec.get('mode', 'rw') == 'ro' }
+            elif self._schema and self._schema.get('schema') == 3 and spec == None:
+                # Add support for volumes with no host binding
+                result[src] = {}
+                return
             else:
                 raise exceptions.InvalidVolumeConfigurationException(
                     'Invalid volume specification for container {}: {} -> {}'

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -183,8 +183,8 @@ class StartTask(Task):
                 and map(lambda p: tuple(p['exposed'].split('/')),
                         self.container.ports.values()) \
                 or None
-            volumes = [volume['bind'] for volume in
-                       self.container.volumes.values()]
+
+            volumes = [v for v in self.container.volumes.keys()]
 
             self.o.pending('creating container from {}...'.format(
                 self.container.short_image))
@@ -217,9 +217,16 @@ class StartTask(Task):
 
         self.o.pending('starting container {}...'
                        .format(self.container.id[:7]))
+        
+        # Invert dictionnary only for schema version 3
+        if self.container._schema['schema'] == 3:
+            volumes = {v['bind']: {'bind': k, 'ro': v['ro']} for (k, v) in self.container.volumes.items() if v and 'bind' in v}
+        else:
+            volumes = self.container.volumes
+
         self.container.ship.backend.start(
             self.container.id,
-            binds=self.container.volumes,
+            binds=volumes,
             port_bindings=ports,
             privileged=self.container.privileged,
             network_mode=self.container.network_mode,

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -184,7 +184,10 @@ class StartTask(Task):
                         self.container.ports.values()) \
                 or None
 
-            volumes = [v for v in self.container.volumes.keys()]
+            if self.container._schema['schema'] == 3:
+                volumes = [v for v in self.container.volumes.keys()]
+            else
+                volumes = [volume['bind'] for volume in self.container.volumes.values()]
 
             self.o.pending('creating container from {}...'.format(
                 self.container.short_image))

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -186,7 +186,7 @@ class StartTask(Task):
 
             if self.container._schema['schema'] == 3:
                 volumes = [v for v in self.container.volumes.keys()]
-            else
+            else:
                 volumes = [volume['bind'] for volume in self.container.volumes.values()]
 
             self.o.pending('creating container from {}...'.format(

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -220,10 +220,10 @@ class StartTask(Task):
 
         self.o.pending('starting container {}...'
                        .format(self.container.id[:7]))
-        
         # Invert dictionnary only for schema version 3
         if self.container._schema['schema'] == 3:
-            volumes = {v['bind']: {'bind': k, 'ro': v['ro']} for (k, v) in self.container.volumes.items() if v and 'bind' in v}
+            volumes = {v['bind']: {'bind': k, 'ro': v['ro']} for (k, v) 
+                    in self.container.volumes.items() if v and 'bind' in v}
         else:
             volumes = self.container.volumes
 

--- a/maestro/version.py
+++ b/maestro/version.py
@@ -1,2 +1,2 @@
 name = 'maestro'
-version = '0.2.4.3-dev'
+version = '0.2.4.2-dev'

--- a/maestro/version.py
+++ b/maestro/version.py
@@ -1,2 +1,2 @@
 name = 'maestro'
-version = '0.2.4.2-dev'
+version = '0.2.4.3-dev'


### PR DESCRIPTION
Yaml 'volumes' key inverts logic with container/path: {'target': '/path/to/host', 'mode': <mode>}