### PR TITLE
Add support for cap_add, cap_drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ be placed on (by name). Additionally, it may define:
     defined at the service level);
   - `privileged`, a boolean specifying whether the container should run
     in privileged mode or not (defaults to `false`);
+  - `cap_add`, Linux capabilities to add to the container (see <a href="https://docs.docker.com/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration">docker run</a>'s explanation);
+  - `cap_drop`, Linux capabilities to drop from the container;
   - `stop_timeout`, the number of seconds Docker will wait between
     sending `SIGTERM` and `SIGKILL` (defaults to 10);
   - `limits`:

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -363,6 +363,10 @@ class Container(Entity):
         # Should this container run with -privileged?
         self.privileged = config.get('privileged', False)
 
+        # Add or drop privileges
+        self.cap_add = config.get('cap_add', None)
+        self.cap_drop = config.get('cap_drop', None)
+
         # Network mode
         self.network_mode = config.get('net')
 

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -222,6 +222,8 @@ class StartTask(Task):
             port_bindings=ports,
             lxc_conf=self.container.lxc_conf,
             privileged=self.container.privileged,
+            cap_add=self.container.cap_add,
+            cap_drop=self.container.cap_drop,
             network_mode=self.container.network_mode,
             restart_policy=self.container.restart_policy,
             dns=self.container.dns,


### PR DESCRIPTION
Per discussion in https://github.com/signalfuse/maestro-ng/issues/125, add support for cap_add and cap_drop. I did a quick search for a unit test for the privileged tag and didn't see one; I'm not primarily a python coder so not too confident in my ability to create one. But hopefully this gets us started.