### PR TITLE
Add support for extra_hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ be placed on (by name). Additionally, it may define:
   - `cap_add`, Linux capabilities to add to the container (see the
     documentation for [docker run](https://docs.docker.com/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration));
   - `cap_drop`, Linux capabilities to drop from the container;
+  - `extra_hosts`, map a custom host to an IP for the container. Example: `<hostname>: <ip address>`;
   - `stop_timeout`, the number of seconds Docker will wait between
     sending `SIGTERM` and `SIGKILL` (defaults to 10);
   - `limits`:

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -367,6 +367,9 @@ class Container(Entity):
         self.cap_add = config.get('cap_add', None)
         self.cap_drop = config.get('cap_drop', None)
 
+        # Add extra hosts
+        self.extra_hosts = config.get('extra_hosts', None)
+
         # Network mode
         self.network_mode = config.get('net')
 

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -224,6 +224,7 @@ class StartTask(Task):
             privileged=self.container.privileged,
             cap_add=self.container.cap_add,
             cap_drop=self.container.cap_drop,
+            extra_hosts=self.container.extra_hosts,
             network_mode=self.container.network_mode,
             restart_policy=self.container.restart_policy,
             dns=self.container.dns,


### PR DESCRIPTION
I add a feature allowed by docker-py to map hostname with an IP in container (`/etc/hosts`). I use this feature to add custom hosts inside my containers and I think it's a good point to add this to Maestro.