### PR TITLE
Add include_services

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ ship_defaults:
   # defaults for some of the ship attributes (see below)
 ships:
   # Ship definitions (see below)
+include_services:
+  # Load services from a different configuration file
 services:
   # Service definitions (see below)
 ```
@@ -332,6 +334,32 @@ services:
           name: on-failure
           maximum_retry_count: 3
 ```
+
+You can also create separate files to put your services in. First of all, defines your services in a file:
+
+```yaml
+---
+
+mysql:
+  image: mysql
+  instances:
+    mysql-server-1: { ... }
+
+web:
+  image: nginx
+  requires: [ mysql ]
+  instances:
+    www-1: { ... }
+```
+
+Then you can include this YAML file with the `include_services` keyword in your `maestro.yaml` file:
+
+```yaml
+include_services:
+  - webservice.yaml
+  - monitoring.yaml
+```
+
 
 ## Defining dependencies
 

--- a/maestro/__main__.py
+++ b/maestro/__main__.py
@@ -216,10 +216,24 @@ def execute(options, config):
     return 1
 
 
+def parse_include_services(options, config):
+    """Load services from seperate config files."""
+    services = config.get('services', {})
+
+    includes = config.pop('include_services', [])
+
+    for path in includes:
+        path = os.path.join(os.path.dirname(options.file), path)
+        services.update(load_config_from_file(path))
+
+    return config
+
+
 def main(args=None, config=None):
     options = create_parser().parse_args(args)
     if config is None:
         config = load_config_from_file(options.file)
+        parse_include_services(options, config)
     return execute(options, config)
 
 


### PR DESCRIPTION
I have implemented an option to include services from other files. We can use it to reduce the size of the maestro.yaml file and improve its readability. To do that, I have had a top level keyword "include_services" to specify a list of files to include (see README for more information).

