### PR TITLE
Introduced logdriver (logconfig) support, including tests.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -212,6 +212,8 @@ be placed on (by name). Additionally, it may define:
       container;
     - `swap`, the swap limit of the container (in bytes, or with one
       of the `k`, `m` or `g` suffixes, also valid in uppercase);
+  - `log_driver`, one of the supported log drivers, e.g. syslog or json-file.
+  - `log_opt`, a set of key value pairs that provide additional logging parameters. E.g. the syslog-address to redirect syslog output to another address.
   - `command`, to specify or override the command executed by the
     container;
   - `net`, to specify the container's network mode (one of `bridge` --

--- a/maestro/exceptions.py
+++ b/maestro/exceptions.py
@@ -66,3 +66,8 @@ class InvalidVolumeConfigurationException(MaestroException):
 
 class InvalidAuditorConfigurationException(MaestroException):
     """Invalid configuration of one of the specified auditors."""
+
+
+class InvalidLogConfigurationException(MaestroException):
+    """Error thrown when a log_driver or log_opt is in an invalid format."""
+    pass

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -208,9 +208,8 @@ class StartTask(Task):
                 name=self.container.name,
                 environment=self.container.env,
                 volumes=list(self.container.get_volumes()),
-                mem_limit=self.container.mem_limit,
-                memswap_limit=self.container.memswap_limit,
                 cpu_shares=self.container.cpu_shares,
+                host_config=self.container.host_config,
                 ports=ports,
                 detach=True,
                 working_dir=self.container.workdir,
@@ -232,19 +231,7 @@ class StartTask(Task):
         self.o.pending('starting container {}...'
                        .format(self.container.id[:7]))
         self.container.ship.backend.start(
-            self.container.id,
-            binds=self.container.volumes,
-            port_bindings=ports,
-            lxc_conf=self.container.lxc_conf,
-            privileged=self.container.privileged,
-            cap_add=self.container.cap_add,
-            cap_drop=self.container.cap_drop,
-            extra_hosts=self.container.extra_hosts,
-            network_mode=self.container.network_mode,
-            restart_policy=self.container.restart_policy,
-            dns=self.container.dns,
-            links=self.container.links,
-            volumes_from=list(self.container.volumes_from))
+            self.container.id)
 
         # Waiting one second and checking container state again to make sure
         # initialization didn't fail.


### PR DESCRIPTION
Added host_config to support log config. Added all start parameters to host_config as well, since they are deprecated on the container.start() and cause incorrect behavior. Removed the parameters from container start.