### PR TITLE
Maestro logs

### DIFF
--- a/maestro/maestro.py
+++ b/maestro/maestro.py
@@ -403,8 +403,8 @@ class Conductor:
             o.pending(
                 'Requesting logs for {}. This may take a while...'
                 .format(container.name))
-            logs = container.ship.backend.logs(container.id).decode('utf-8')
-            logs = logs.split('\n')[-int(n or len(logs)):]
+            logs = container.ship.backend.logs(
+                container.id, tail=n).decode('utf-8').splitlines()
 
         o.pending('\033[2K')
         for line in logs:

--- a/maestro/maestro.py
+++ b/maestro/maestro.py
@@ -398,7 +398,24 @@ class Conductor:
             o.pending(
                 'Now streaming logs for {}. New output will appear below.'
                 .format(container.name))
-            logs = container.ship.backend.attach(container.id, stream=True)
+
+            while True:
+                logs = container.ship.backend.attach(container.id, stream=True)
+                o.pending('\033[2K')
+                for line in logs:
+                    print(line.rstrip())
+
+                o.pending('{} has died, waiting for respawn...'
+                          .format(container.name))
+
+                events = container.ship.backend.events(decode=True)
+                for e in events:
+                    if e['status'] == 'start':
+                        spec = container.ship.backend.inspect_container(
+                            e['id'])
+                        if spec['Name'][1:] == container.name:
+                            container.id = e['id']
+                            break
         else:
             o.pending(
                 'Requesting logs for {}. This may take a while...'
@@ -406,9 +423,9 @@ class Conductor:
             logs = container.ship.backend.logs(
                 container.id, tail=n).decode('utf-8').splitlines()
 
-        o.pending('\033[2K')
-        for line in logs:
-            print(line.rstrip())
+            o.pending('\033[2K')
+            for line in logs:
+                print(line.rstrip())
 
     def deptree(self, things, recursive, **kwargs):
         """Display the dependency tree of the given services."""


### PR DESCRIPTION
This pull request modifies two things:

* I've done a quick optimization with `maestro logs` implementation, I use directly the tail argument from the docker-py API.
* I've modify `maestro logs -F` to continue to print logs even if the container is restarted. I do by tracking events in docker and if a container with the same name is started, Maestro will print logs of the new container (even if the container ID changes).