### PR TITLE
Fix for exception when pulling two instances for same repo

### DIFF
--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -410,8 +410,9 @@ class PullTask(Task):
         # Pull the image (this may be a no-op, but that's fine).
         for dlstatus in self.container.ship.backend.pull(
                 stream=True, insecure_registry=insecure, **image):
-            percentage = self._update_pull_progress(dlstatus)
-            self.o.pending('... {:.1f}%'.format(percentage))
+            if dlstatus:
+                percentage = self._update_pull_progress(dlstatus)
+                self.o.pending('... {:.1f}%'.format(percentage))
 
         if self._standalone:
             self.o.commit(CONTAINER_STATUS_FMT.format(''))


### PR DESCRIPTION
See https://github.com/signalfuse/maestro-ng/issues/147

Fix is by checking if non-empty dlstatus is returned. Only then the percentage can be updated in the terminal.

Did a simple test before and after fix with 5 instances of same service.